### PR TITLE
removed defaults from CMD, DATA0 and CLK pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ sd_mmc_card:
 * **data2_pin**: (Optional, GPIO): data 2 pin, only use in 4bit mode
 * **data3_pin**: (Optional, GPIO): data 3 pin, only use in 4bit mode
 
+In case of connecting in 1-bit lane also known as SPI mode you can use table below to "convert" pin naming:
+
+|SPI naming|MMC naming|
+|--|--|
+|MISO|DATA0|
+|CLK/SCK|CLK|
+|MOSI|CMD|
+|SS/CS|DATA3|
+
 ## Actions
 
 ### Write file

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -41,9 +41,9 @@ def validate_raw_data(value):
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(SdMmc),
-        cv.Optional(CONF_CLK_PIN): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_CMD_PIN): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_DATA0_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),
+        cv.Required(CONF_CLK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_CMD_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_DATA0_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),
         cv.Optional(CONF_DATA1_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),
         cv.Optional(CONF_DATA2_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),
         cv.Optional(CONF_DATA3_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -41,9 +41,9 @@ def validate_raw_data(value):
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(SdMmc),
-        cv.Optional(CONF_CLK_PIN, default="GPIO14"): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_CMD_PIN, default="GPIO15"): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_DATA0_PIN, default="GPIO2"): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),
+        cv.Optional(CONF_CLK_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_CMD_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_DATA0_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),
         cv.Optional(CONF_DATA1_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),
         cv.Optional(CONF_DATA2_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),
         cv.Optional(CONF_DATA3_PIN): pins.gpio_pin_schema({CONF_OUTPUT: True, CONF_INPUT: True}),


### PR DESCRIPTION
To fix early validation - removed default values for pins  CMD, DATA0 and CLK.