### PR TITLE
Fix list_directory crash & noisy logs + add frequency sensor, fs_type text sensor, and format_card action

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ esp32:
       disable_vfs_support_dir: false
 ```
 
+> **Note:** The `frequency` sensor, `fs_type` text sensor, and `sd_mmc_card.format_card` action are **ESP-IDF only** and are not available with the Arduino framework.
+
 #### ESP-IDF Framework
 
 ESPHome excludes certain built-in IDF components by default to reduce compile time. We should include ```["fatfs", "spiffs"]``` components. [See Built-in IDF Component Inclusion in ESPHome](https://esphome.io/components/esp32/#advanced-configuration)

--- a/components/sd_mmc_card/README.md
+++ b/components/sd_mmc_card/README.md
@@ -5,10 +5,11 @@ SD MMC cards components for esphome.
 * [Config](#config)
   * [Notes](#notes)
     * [Arduino Framework](#arduino-framework)
-    * [ESP-IDF Framework](#esp-idf-framework) 
+    * [ESP-IDF Framework](#esp-idf-framework)
   * [Devices Examples](#devices-examples)
   * [Actions](#actions)
   * [Sensors](#sensors)
+  * [Text Sensors](#text-sensors)
   * [Others](#others)
   * [Helpers](#helpers)
 
@@ -195,6 +196,15 @@ sd_mmc_card.remove_directory:
     path: "/test"
 ```
 
+### Format card *(ESP-IDF only)*
+
+Format the SD card. **All data on the card will be erased.**
+
+```yaml
+sd_mmc_card.format_card:
+    id: sd_mmc_card
+```
+
 ## Sensors
 
 ### Used space
@@ -236,6 +246,21 @@ Free capacity of the sd card
 
 * All the [sensor](https://esphome.io/components/sensor/) options
 
+### Frequency *(ESP-IDF only)*
+
+```yaml
+sensor:
+  - platform: sd_mmc_card
+    type: frequency
+    name: "SD Frequency"
+    unit_of_measurement: kHz
+    accuracy_decimals: 0
+```
+
+SD/MMC bus frequency in kHz as negotiated at mount time.
+
+* All the [sensor](https://esphome.io/components/sensor/) options
+
 ### File size
 
 ```yaml
@@ -264,6 +289,19 @@ sd card type (MMC, SDSC, ...)
 
 * All the [text sensor](https://esphome.io/components/text_sensor/) options
 
+### Filesystem type *(ESP-IDF only)*
+
+```yaml
+text_sensor:
+  - platform: sd_mmc_card
+    fs_type:
+      name: "SD Filesystem"
+```
+
+FAT filesystem type string: `FAT12`, `FAT16`, `FAT32`, `exFAT`, or `UNKNOWN`. Published once at boot.
+
+* All the [text sensor](https://esphome.io/components/text_sensor/) options
+
 ## Others
 
 ### List Directory
@@ -276,13 +314,7 @@ std::vector<std::string> list_directory(std::string path, uint8_t depth);
 * **path** : root directory
 * **depth**: max depth 
 
-Example
-
-```yaml
-- lambda: |
-  for (auto const & file : id(esp_camera_sd_card)->list_directory("/", 1))
-    ESP_LOGE("   ", "File: %s\n", file.c_str());
-```
+> **Warning:** `list_directory()` has a known crash bug. Use `list_directory_file_info()` instead (see below).
 
 ### List Directory File Info
 

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -38,6 +38,8 @@ SdMmcAppendFileAction = sd_mmc_card_component_ns.class_("SdMmcAppendFileAction",
 SdMmcCreateDirectoryAction = sd_mmc_card_component_ns.class_("SdMmcCreateDirectoryAction", automation.Action)
 SdMmcRemoveDirectoryAction = sd_mmc_card_component_ns.class_("SdMmcRemoveDirectoryAction", automation.Action)
 SdMmcDeleteFileAction = sd_mmc_card_component_ns.class_("SdMmcDeleteFileAction", automation.Action)
+SdMmcFormatAction = sd_mmc_card_component_ns.class_("SdMmcFormatAction", automation.Action)
+
 
 def validate_raw_data(value):
     if isinstance(value, str):
@@ -178,4 +180,13 @@ async def sd_mmc_delete_file_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, parent)
     path_ = await cg.templatable(config[CONF_PATH], args, cg.std_string)
     cg.add(var.set_path(path_))
+    return var
+
+
+@automation.register_action(
+    "sd_mmc_card.format_card", SdMmcFormatAction, cv.Schema({cv.GenerateID(): cv.use_id(SdMmc)})
+)
+async def sd_mmc_format_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
     return var

--- a/components/sd_mmc_card/sd_mmc_card.cpp
+++ b/components/sd_mmc_card/sd_mmc_card.cpp
@@ -37,6 +37,7 @@ void SdMmc::dump_config() {
   LOG_SENSOR("  ", "Used space", this->used_space_sensor_);
   LOG_SENSOR("  ", "Total space", this->total_space_sensor_);
   LOG_SENSOR("  ", "Free space", this->free_space_sensor_);
+  LOG_SENSOR("  ", "Frequency", this->frequency_sensor_);
   for (auto &sensor : this->file_size_sensors_) {
     if (sensor.sensor != nullptr)
       LOG_SENSOR("  ", "File size", sensor.sensor);
@@ -44,6 +45,7 @@ void SdMmc::dump_config() {
 #endif
 #ifdef USE_TEXT_SENSOR
   LOG_TEXT_SENSOR("  ", "SD Card Type", this->sd_card_type_text_sensor_);
+  LOG_TEXT_SENSOR("  ", "Filesystem Type", this->fs_type_text_sensor_);
 #endif
 
   if (this->is_failed()) {
@@ -65,7 +67,10 @@ void SdMmc::append_file(const char *path, const uint8_t *buffer, size_t len) {
 std::vector<std::string> SdMmc::list_directory(const char *path, uint8_t depth) {
   std::vector<std::string> list;
   std::vector<FileInfo> infos = list_directory_file_info(path, depth);
-  std::transform(infos.cbegin(), infos.cend(), list.begin(), [](FileInfo const &info) { return info.path; });
+  // FIX: original used list.begin() on an empty vector — undefined behaviour
+  // that caused a LoadProhibited crash. std::back_inserter grows the vector.
+  std::transform(infos.cbegin(), infos.cend(), std::back_inserter(list),
+                 [](FileInfo const &info) { return info.path; });
   return list;
 }
 

--- a/components/sd_mmc_card/sd_mmc_card.h
+++ b/components/sd_mmc_card/sd_mmc_card.h
@@ -42,9 +42,13 @@ class SdMmc : public Component {
   SUB_SENSOR(used_space)
   SUB_SENSOR(total_space)
   SUB_SENSOR(free_space)
+  // SD/MMC bus frequency in kHz (ESP-IDF only; Arduino does not expose this)
+  SUB_SENSOR(frequency)
 #endif
 #ifdef USE_TEXT_SENSOR
   SUB_TEXT_SENSOR(sd_card_type)
+  // filesystem type string (FAT12 / FAT16 / FAT32 / exFAT — ESP-IDF only)
+  SUB_TEXT_SENSOR(fs_type)
 #endif
  public:
   enum ErrorCode {
@@ -62,6 +66,7 @@ class SdMmc : public Component {
   bool delete_file(std::string const &path);
   bool create_directory(const char *path);
   bool remove_directory(const char *path);
+  bool format_card();
   std::vector<uint8_t> read_file(char const *path);
   std::vector<uint8_t> read_file(std::string const &path);
   bool is_directory(const char *path);
@@ -110,6 +115,7 @@ class SdMmc : public Component {
 #endif
 #ifdef USE_ESP_IDF
   std::string sd_card_type() const;
+  std::string fs_type() const;
 #endif
   std::vector<FileInfo> &list_directory_file_info_rec(const char *path, uint8_t depth, std::vector<FileInfo> &list);
   static std::string error_code_to_string(ErrorCode);
@@ -184,6 +190,16 @@ template<typename... Ts> class SdMmcDeleteFileAction : public Action<Ts...> {
     auto path = this->path_.value(x...);
     this->parent_->delete_file(path.c_str());
   }
+
+ protected:
+  SdMmc *parent_;
+};
+
+template<typename... Ts> class SdMmcFormatAction : public Action<Ts...> {
+ public:
+  SdMmcFormatAction(SdMmc *parent) : parent_(parent) {}
+
+  void play(const Ts &...x) override { this->parent_->format_card(); }
 
  protected:
   SdMmc *parent_;

--- a/components/sd_mmc_card/sd_mmc_card_esp32_arduino.cpp
+++ b/components/sd_mmc_card/sd_mmc_card_esp32_arduino.cpp
@@ -64,8 +64,14 @@ void SdMmc::write_file(const char *path, const uint8_t *buffer, size_t len, cons
 
 bool SdMmc::create_directory(const char *path) {
   ESP_LOGV(TAG, "Create directory: %s", path);
+  // FIX: SD_MMC.mkdir returns false both for real errors and when the directory
+  // already exists. Check existence first so we don't log a false error.
+  if (SD_MMC.exists(path)) {
+    ESP_LOGI(TAG, "Directory already exists: %s", path);
+    return true;
+  }
   if (!SD_MMC.mkdir(path)) {
-    ESP_LOGE(TAG, "Failed to create directory");
+    ESP_LOGE(TAG, "Failed to create directory: %s", path);
     return false;
   }
   this->update_sensors();
@@ -75,7 +81,7 @@ bool SdMmc::create_directory(const char *path) {
 bool SdMmc::remove_directory(const char *path) {
   ESP_LOGV(TAG, "Remove directory: %s", path);
   if (!SD_MMC.rmdir(path)) {
-    ESP_LOGE(TAG, "Failed to remove directory");
+    ESP_LOGE(TAG, "Failed to remove directory: %s", path);
     return false;
   }
   this->update_sensors();
@@ -85,7 +91,7 @@ bool SdMmc::remove_directory(const char *path) {
 bool SdMmc::delete_file(const char *path) {
   ESP_LOGV(TAG, "Delete File: %s", path);
   if (!SD_MMC.remove(path)) {
-    ESP_LOGE(TAG, "failed to remove file");
+    ESP_LOGE(TAG, "failed to remove file: %s", path);
     return false;
   }
   this->update_sensors();

--- a/components/sd_mmc_card/sd_mmc_card_esp_idf.cpp
+++ b/components/sd_mmc_card/sd_mmc_card_esp_idf.cpp
@@ -8,6 +8,7 @@
 #include "sdmmc_cmd.h"
 #include "driver/sdmmc_host.h"
 #include "driver/sdmmc_types.h"
+#include "ff.h"
 
 int constexpr SD_OCR_SDHC_CAP = (1 << 30);  // value defined in esp-idf/components/sdmmc/include/sd_protocol_defs.h
 
@@ -68,6 +69,8 @@ void SdMmc::setup() {
 #ifdef USE_TEXT_SENSOR
   if (this->sd_card_type_text_sensor_ != nullptr)
     this->sd_card_type_text_sensor_->publish_state(sd_card_type());
+  if (this->fs_type_text_sensor_ != nullptr)
+    this->fs_type_text_sensor_->publish_state(fs_type());
 #endif
 
   update_sensors();
@@ -93,6 +96,11 @@ bool SdMmc::create_directory(const char *path) {
   ESP_LOGV(TAG, "Create directory: %s", path);
   std::string absolut_path = build_path(path);
   if (mkdir(absolut_path.c_str(), 0777) < 0) {
+    if (errno == EEXIST) {
+      // Directory already exists — not an error
+      ESP_LOGI(TAG, "Directory already exists: %s", path);
+      return true;
+    }
     ESP_LOGE(TAG, "Failed to create a new directory: %s", strerror(errno));
     return false;
   }
@@ -109,6 +117,7 @@ bool SdMmc::remove_directory(const char *path) {
   std::string absolut_path = build_path(path);
   if (remove(absolut_path.c_str()) != 0) {
     ESP_LOGE(TAG, "Failed to remove directory: %s", strerror(errno));
+    return false;
   }
   this->update_sensors();
   return true;
@@ -123,6 +132,7 @@ bool SdMmc::delete_file(const char *path) {
   std::string absolut_path = build_path(path);
   if (remove(absolut_path.c_str()) != 0) {
     ESP_LOGE(TAG, "Failed to remove file: %s", strerror(errno));
+    return false;
   }
   this->update_sensors();
   return true;
@@ -158,7 +168,13 @@ std::vector<FileInfo> &SdMmc::list_directory_file_info_rec(const char *path, uin
   std::string absolut_path = build_path(path);
   DIR *dir = opendir(absolut_path.c_str());
   if (!dir) {
-    ESP_LOGE(TAG, "Failed to open directory: %s", strerror(errno));
+    if (errno == ENOENT) {
+      // Path does not exist — warn, not error (e.g. empty-path retry before "/")
+      ESP_LOGW(TAG, "Directory not found: %s", path);
+    } else {
+      // Something genuinely wrong (permission denied, I/O error, etc.)
+      ESP_LOGE(TAG, "Failed to open directory %s: %s", path, strerror(errno));
+    }
     return list;
   }
   char entry_absolut_path[FILE_PATH_MAX];
@@ -185,7 +201,7 @@ std::vector<FileInfo> &SdMmc::list_directory_file_info_rec(const char *path, uin
     }
     list.emplace_back(entry_path, file_size, entry->d_type == DT_DIR);
     if (entry->d_type == DT_DIR && depth)
-      list_directory_file_info_rec(entry_absolut_path, depth - 1, list);
+      list_directory_file_info_rec(entry_path, depth - 1, list);
   }
   closedir(dir);
   return list;
@@ -205,10 +221,31 @@ size_t SdMmc::file_size(const char *path) {
   struct stat info;
   size_t file_size = 0;
   if (stat(absolut_path.c_str(), &info) < 0) {
-    ESP_LOGE(TAG, "Failed to stat file: %s", strerror(errno));
-    return -1;
+    if (errno == ENOENT) {
+      // File does not exist — this is expected (e.g. sensor polling before
+      // first write). Warn so the user can see the state, but it is not an error.
+      ESP_LOGW(TAG, "File not found: %s", path);
+    } else {
+      // Genuine I/O or permission problem
+      ESP_LOGE(TAG, "Failed to stat %s: %s", path, strerror(errno));
+    }
+    // FIX: original returned (size_t)-1 which wraps to ~4 GB on 32-bit size_t.
+    // Return 0 so sensors show 0 B for missing files instead of 4294967296 B.
+    return 0;
   }
   return info.st_size;
+}
+
+bool SdMmc::format_card() {
+  ESP_LOGW(TAG, "Formatting SD card at %s...", MOUNT_POINT.c_str());
+  esp_err_t err = esp_vfs_fat_sdcard_format(MOUNT_POINT.c_str(), this->card_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Format failed: %s", esp_err_to_name(err));
+    return false;
+  }
+  ESP_LOGI(TAG, "Format complete");
+  this->update_sensors();
+  return true;
 }
 
 std::string SdMmc::sd_card_type() const {
@@ -220,6 +257,22 @@ std::string SdMmc::sd_card_type() const {
     return (this->card_->ocr & SD_OCR_SDHC_CAP) ? "SDHC/SDXC" : "SDSC";
   }
   return "UNKNOWN";
+}
+
+std::string SdMmc::fs_type() const {
+  FATFS *fs = nullptr;
+  DWORD free_clust = 0;
+  if (f_getfree(MOUNT_POINT.c_str(), &free_clust, &fs) != FR_OK || fs == nullptr)
+    return "UNKNOWN";
+  switch (fs->fs_type) {
+    case FS_FAT12: return "FAT12";
+    case FS_FAT16: return "FAT16";
+    case FS_FAT32: return "FAT32";
+#ifdef FS_EXFAT
+    case FS_EXFAT: return "exFAT";
+#endif
+    default: return "UNKNOWN";
+  }
 }
 
 void SdMmc::update_sensors() {
@@ -246,6 +299,9 @@ void SdMmc::update_sensors() {
     this->total_space_sensor_->publish_state(total_bytes);
   if (this->free_space_sensor_ != nullptr)
     this->free_space_sensor_->publish_state(free_bytes);
+
+  if (this->frequency_sensor_ != nullptr)
+    this->frequency_sensor_->publish_state(this->card_->max_freq_khz);
 
   for (auto &sensor : this->file_size_sensors_) {
     if (sensor.sensor != nullptr)

--- a/components/sd_mmc_card/sensor.py
+++ b/components/sd_mmc_card/sensor.py
@@ -19,9 +19,10 @@ CONF_USED_SPACE = "used_space"
 CONF_TOTAL_SPACE = "total_space"
 CONF_FREE_SPACE = "free_space"
 CONF_FILE_SIZE = "file_size"
+CONF_FREQUENCY = "frequency"  # SD/MMC bus frequency in kHz (ESP-IDF only)
 
 TYPES = [CONF_USED_SPACE, CONF_TOTAL_SPACE, CONF_USED_SPACE, CONF_FREE_SPACE]
-SIMPLE_TYPES = [CONF_USED_SPACE, CONF_TOTAL_SPACE, CONF_FREE_SPACE]
+SIMPLE_TYPES = [CONF_USED_SPACE, CONF_TOTAL_SPACE, CONF_FREE_SPACE, CONF_FREQUENCY]
 
 BASE_CONFIG_SCHEMA = sensor.sensor_schema(
     unit_of_measurement=UNIT_BYTES,
@@ -36,14 +37,15 @@ BASE_CONFIG_SCHEMA = sensor.sensor_schema(
 
 CONFIG_SCHEMA = cv.typed_schema(
     {
-        CONF_TOTAL_SPACE : BASE_CONFIG_SCHEMA,
-        CONF_USED_SPACE : BASE_CONFIG_SCHEMA,
+        CONF_TOTAL_SPACE: BASE_CONFIG_SCHEMA,
+        CONF_USED_SPACE: BASE_CONFIG_SCHEMA,
         CONF_FREE_SPACE: BASE_CONFIG_SCHEMA,
+        CONF_FREQUENCY: BASE_CONFIG_SCHEMA,
         CONF_FILE_SIZE: BASE_CONFIG_SCHEMA.extend(
             {
                 cv.Required(CONF_PATH): cv.templatable(cv.string_strict),
             }
-        )
+        ),
     },
     lower=True,
 )

--- a/components/sd_mmc_card/text_sensor.py
+++ b/components/sd_mmc_card/text_sensor.py
@@ -9,10 +9,14 @@ from . import SdMmc, CONF_SD_MMC_CARD_ID
 DEPENDENCIES = ["sd_mmc_card"]
 
 CONF_SD_CARD_TYPE = "sd_card_type"
+CONF_FS_TYPE = "fs_type"  # FAT12 / FAT16 / FAT32 / exFAT (ESP-IDF only)
 
 CONFIG_SCHEMA = {
     cv.GenerateID(CONF_SD_MMC_CARD_ID): cv.use_id(SdMmc),
     cv.Optional(CONF_SD_CARD_TYPE): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+    ),
+    cv.Optional(CONF_FS_TYPE): text_sensor.text_sensor_schema(
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC
     ),
 }
@@ -23,3 +27,7 @@ async def to_code(config):
     if CONF_SD_CARD_TYPE in config:
         sens = await text_sensor.new_text_sensor(config[CONF_SD_CARD_TYPE])
         cg.add(sd_mmc_component.set_sd_card_type_text_sensor(sens))
+
+    if CONF_FS_TYPE in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_FS_TYPE])
+        cg.add(sd_mmc_component.set_fs_type_text_sensor(sens))

--- a/example.esp-idf.yaml
+++ b/example.esp-idf.yaml
@@ -40,7 +40,7 @@ button:
     on_press:
       then:
         - sd_mmc_card.write_file:
-            path: "/test.txt" 
+            path: "/test.txt"
             data: !lambda |
               std::string str("content");
               return std::vector<uint8_t>(str.begin(), str.end());
@@ -60,7 +60,7 @@ button:
     on_press:
       then:
         - sd_mmc_card.write_file:
-            path: "/test.txt" 
+            path: "/test.txt"
             data: !lambda |
               std::string str("content");
               return std::vector<uint8_t>(str.begin(), str.end());
@@ -68,6 +68,14 @@ button:
         - sd_mmc_card.create_directory:
             path: "/test_dir"
         - logger.log: "directory created"
+
+  # format the card - all data will be erased (ESP-IDF only)
+  - platform: template
+    name: "SD Format Card"
+    on_press:
+      then:
+        - sd_mmc_card.format_card:
+            id: sd_card
 
 sensor:
   - platform: sd_mmc_card
@@ -91,6 +99,13 @@ sensor:
     filters:
       - lambda: return sd_mmc_card::convertBytes(x, sd_mmc_card::MemoryUnits::GigaByte);
 
+  # SD/MMC bus frequency in kHz (ESP-IDF only)
+  - platform: sd_mmc_card
+    type: frequency
+    name: "SD Frequency"
+    unit_of_measurement: kHz
+    accuracy_decimals: 0
+
   - platform: sd_mmc_card
     type: file_size
     name: "text.txt size"
@@ -103,6 +118,9 @@ text_sensor:
   - platform: sd_mmc_card
     sd_card_type:
       name: "SD card type"
+    # FAT filesystem type - FAT12/FAT16/FAT32/exFAT (ESP-IDF only)
+    fs_type:
+      name: "SD Filesystem"
 
 web_server:
 

--- a/example.yaml
+++ b/example.yaml
@@ -36,7 +36,7 @@ button:
     on_press:
       then:
         - sd_mmc_card.write_file:
-            path: "/test.txt" 
+            path: "/test.txt"
             data: !lambda |
               std::string str("content");
               return std::vector<uint8_t>(str.begin(), str.end());
@@ -56,7 +56,7 @@ button:
     on_press:
       then:
         - sd_mmc_card.write_file:
-            path: "/test.txt" 
+            path: "/test.txt"
             data: !lambda |
               std::string str("content");
               return std::vector<uint8_t>(str.begin(), str.end());
@@ -64,6 +64,8 @@ button:
         - sd_mmc_card.create_directory:
             path: "/test_dir"
         - logger.log: "directory created"
+
+  # Note: sd_mmc_card.format_card is ESP-IDF only and not available here.
 
 sensor:
   - platform: sd_mmc_card
@@ -87,6 +89,8 @@ sensor:
     filters:
       - lambda: return sd_mmc_card::convertBytes(x, sd_mmc_card::MemoryUnits::GigaByte);
 
+  # Note: frequency sensor is ESP-IDF only and not available here.
+
   - platform: sd_mmc_card
     type: file_size
     name: "text.txt size"
@@ -99,6 +103,7 @@ text_sensor:
   - platform: sd_mmc_card
     sd_card_type:
       name: "SD card type"
+  # Note: fs_type text sensor is ESP-IDF only and not available here.
 
 web_server:
 


### PR DESCRIPTION
## Summary

This PR fixes three bugs present in the current codebase and adds three
new features for the ESP-IDF framework.

---

## Bug Fixes

### 🐛 `list_directory()` crash (LoadProhibited fault)

`list_directory()` in `sd_mmc_card.cpp` called `std::transform` with
`list.begin()` as the output iterator on an empty vector. Writing to an
iterator into an empty vector is undefined behaviour and caused a
`LoadProhibited` hardware fault on ESP32-S3, rebooting the device every
time the function was called.

**Fix:** replaced `list.begin()` with `std::back_inserter(list)` so the
vector grows as elements are inserted.

> **Note:** `list_directory()` should be avoided entirely — use
> `list_directory_file_info()` instead, which does not have this issue.
> Documentation and examples updated accordingly.

---

### 🐛 `create_directory()` logs false ERROR when directory already exists

`mkdir()` returns `EEXIST` when the target directory already exists,
which is a normal and expected state (e.g. calling create on boot).
The original code treated this as an error and logged `ESP_LOGE`.

**Fix (ESP-IDF):** check `errno == EEXIST` and log `ESP_LOGI` instead.  
**Fix (Arduino):** call `SD_MMC.exists()` before `mkdir()` and log
`ESP_LOGI` if the directory is already present.

---

### 🐛 `file_size()` returns `~4 GB` when file does not exist

`stat()` failure returned `(size_t)-1` which wraps to `4294967295` on a
32-bit `size_t`. This caused the file size sensor to publish
`4294967296 B` whenever the monitored file was absent (e.g. after
deletion or before first write).

**Fix:** return `0` on stat failure. Log level is now context-aware:
- `errno == ENOENT` → `ESP_LOGW` (file not found — expected state)
- any other errno → `ESP_LOGE` (genuine I/O or permission error)

Same errno-aware approach applied to `list_directory_file_info_rec()`
for the "Failed to open directory" message that fired harmlessly on the
empty-path retry before `"/"`.

---

## New Features *(ESP-IDF framework only)*

### ✨ `frequency` sensor

Exposes the SD/MMC bus frequency in kHz as negotiated at mount time
(`card_->max_freq_khz`). Published on mount and on every
`update_sensors()` call.
```yaml
sensor:
  - platform: sd_mmc_card
    type: frequency
    name: "SD Frequency"
    unit_of_measurement: kHz
    accuracy_decimals: 0
```

---

### ✨ `fs_type` text sensor

Exposes the FAT filesystem type string (`FAT12`, `FAT16`, `FAT32`,
`exFAT`, or `UNKNOWN`) read from the FatFS `FATFS` struct via
`f_getfree`. Published once at mount alongside `sd_card_type`.
```yaml
text_sensor:
  - platform: sd_mmc_card
    fs_type:
      name: "SD Filesystem"
```

---

### ✨ `sd_mmc_card.format_card` action

Formats the SD card using `esp_vfs_fat_sdcard_format()`. Sensors are
refreshed automatically after a successful format. The card remains
mounted — no remount required.
```yaml
button:
  - platform: template
    name: "SD Format Card"
    on_press:
      then:
        - sd_mmc_card.format_card:
            id: sd_mmc_card
```

> ⚠️ **All data on the card will be erased.**