### PR TITLE
Fix DELETE support for ESP-IDF + add synchronous flag to remove warnings

### DIFF
--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -24,7 +24,7 @@ void SDFileServer::dump_config() {
 }
 
 bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
-   if (url == "/favicon.ico" || url == "/robots.txt") { return false; }
+  if (url == "/favicon.ico" || url == "/robots.txt") { return false; }
   ESP_LOGD(TAG, "can handle %s %u", request->url().c_str(),
            str_startswith(std::string(request->url().c_str()), this->build_prefix()));
   return str_startswith(std::string(request->url().c_str()), this->build_prefix());

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -24,9 +24,9 @@ void SDFileServer::dump_config() {
 }
 
 bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
-  ESP_LOGD(TAG, "can handle %s %u", request->url_to().c_str(),
-           str_startswith(std::string(request->url_to().c_str()), this->build_prefix()));
-  return str_startswith(std::string(request->url_to().c_str()), this->build_prefix());
+  ESP_LOGD(TAG, "can handle %s %u", request->url().c_str(),
+           str_startswith(std::string(request->url().c_str()), this->build_prefix()));
+  return str_startswith(std::string(request->url().c_str()), this->build_prefix());
 }
 
 void SDFileServer::handleRequest(AsyncWebServerRequest *request) {

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -30,18 +30,26 @@ bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
 }
 
 void SDFileServer::handleRequest(AsyncWebServerRequest *request) {
-  ESP_LOGD(TAG, "%s", request->url().c_str());
-  if (str_startswith(std::string(request->url().c_str()), this->build_prefix())) {
-    if (request->method() == HTTP_GET) {
-      this->handle_get(request);
-      return;
-    }
-    if (request->hasParam("delete")) {
-    // if (request->method() == HTTP_DELETE) {
-      this->handle_delete(request);
-      return;
-    }
+  const std::string url = request->url().c_str();
+
+  ESP_LOGD(TAG, "REQUEST: %s", url.c_str());
+
+  // sicurezza: filtra solo il nostro prefix
+  if (!str_startswith(url, this->build_prefix())) {
+    return;
   }
+
+  if (request->method() == HTTP_GET && !request->hasParam("delete")) {
+    ESP_LOGD(TAG, "GET file request");
+    this->handle_get(request);
+    return;
+  }
+  if (request->hasParam("delete")) {
+    ESP_LOGD(TAG, "DELETE file request via param");
+    this->handle_delete(request);
+    return;
+  }
+  request->send(400, "text/plain", "Unsupported request");
 }
 
 void SDFileServer::handleUpload(AsyncWebServerRequest *request, const std::string &filename, size_t index, uint8_t *data,

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -24,6 +24,7 @@ void SDFileServer::dump_config() {
 }
 
 bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
+   if (url == "/favicon.ico" || url == "/robots.txt") { return false; }
   ESP_LOGD(TAG, "can handle %s %u", request->url().c_str(),
            str_startswith(std::string(request->url().c_str()), this->build_prefix()));
   return str_startswith(std::string(request->url().c_str()), this->build_prefix());

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -75,7 +75,7 @@ void SDFileServer::handleUpload(AsyncWebServerRequest *request, const std::strin
   }
   this->sd_mmc_card_->append_file(Path::join(path, file_name).c_str(), data, len);
   if (final) {
-    auto response = request->beginResponse(303);
+    auto response = request->beginResponse(303, "text/plain", "");
     response->addHeader("Location", request->url());
     response->addHeader("Connection", "close");
     request->send(response);

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -24,14 +24,9 @@ void SDFileServer::dump_config() {
 }
 
 bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
-  const char *url = request->url().c_str();
-  if (strcmp(url, "/favicon.ico") == 0 || strcmp(url, "/robots.txt") == 0) {
-    return false;
-  }
-  const char *prefix = this->build_prefix().c_str();
-  bool match = str_startswith(url, prefix);
-  ESP_LOGD(TAG, "can a handle %s %u", url, match);
-  return match;
+  ESP_LOGD(TAG, "can handle %s %u", request->url().c_str(),
+           str_startswith(std::string(request->url().c_str()), this->build_prefix()));
+  return str_startswith(std::string(request->url().c_str()), this->build_prefix());
 }
 
 void SDFileServer::handleRequest(AsyncWebServerRequest *request) {

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -75,7 +75,8 @@ void SDFileServer::handleUpload(AsyncWebServerRequest *request, const std::strin
   }
   this->sd_mmc_card_->append_file(Path::join(path, file_name).c_str(), data, len);
   if (final) {
-    auto response = request->beginResponse(201, "text/html", "upload success");
+    auto response = request->beginResponse(303);
+    response->addHeader("Location", request->url());
     response->addHeader("Connection", "close");
     request->send(response);
     return;

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -74,7 +74,7 @@ void SDFileServer::handleUpload(AsyncWebServerRequest *request, const std::strin
     return;
   }
   this->sd_mmc_card_->append_file(Path::join(path, file_name).c_str(), data, len);
-   if (final) {
+  if (final) {
     auto response = request->beginResponse(201, "text/html", "upload success");
     response->addHeader("Connection", "close");
     request->send(response);

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -306,8 +306,7 @@ void SDFileServer::handle_index(AsyncWebServerRequest *request, std::string cons
 
   response->print("</tbody></table>"
                     "<script>"
-                    
-                    "function delete_file(path) {fetch(path + '?delete=1')    .then(r => r.text())    .then(() => location.reload())    .catch(console.error);}"
+                    "function delete_file(path){fetch(path+'?delete=1').then(r=>r.text()).then(()=>location.reload()).catch(console.error);}"
                     "function download_file(path, filename) {"
                     "fetch(path).then(response => response.blob())"
                     ".then(blob => {"

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -36,7 +36,8 @@ void SDFileServer::handleRequest(AsyncWebServerRequest *request) {
       this->handle_get(request);
       return;
     }
-    if (request->method() == HTTP_DELETE) {
+    if (request->hasParam("delete")) {
+    // if (request->method() == HTTP_DELETE) {
       this->handle_delete(request);
       return;
     }

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -24,10 +24,14 @@ void SDFileServer::dump_config() {
 }
 
 bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
-  if (request->url == "/favicon.ico" || request->url == "/robots.txt") { return false; }
-  ESP_LOGD(TAG, "can handle %s %u", request->url().c_str(),
-           str_startswith(std::string(request->url().c_str()), this->build_prefix()));
-  return str_startswith(std::string(request->url().c_str()), this->build_prefix());
+  const char *url = request->url().c_str();
+  if (strcmp(url, "/favicon.ico") == 0 || strcmp(url, "/robots.txt") == 0) {
+    return false;
+  }
+  const char *prefix = this->build_prefix().c_str();
+  bool match = str_startswith(url, prefix);
+  ESP_LOGD(TAG, "can handle %s %u", url, match);
+  return match;
 }
 
 void SDFileServer::handleRequest(AsyncWebServerRequest *request) {

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -24,9 +24,9 @@ void SDFileServer::dump_config() {
 }
 
 bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
-  ESP_LOGD(TAG, "can handle %s %u", request->url().c_str(),
-           str_startswith(std::string(request->url().c_str()), this->build_prefix()));
-  return str_startswith(std::string(request->url().c_str()), this->build_prefix());
+  ESP_LOGD(TAG, "can handle %s %u", request->url_to().c_str(),
+           str_startswith(std::string(request->url_to().c_str()), this->build_prefix()));
+  return str_startswith(std::string(request->url()_to.c_str()), this->build_prefix());
 }
 
 void SDFileServer::handleRequest(AsyncWebServerRequest *request) {

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -26,7 +26,7 @@ void SDFileServer::dump_config() {
 bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
   ESP_LOGD(TAG, "can handle %s %u", request->url_to().c_str(),
            str_startswith(std::string(request->url_to().c_str()), this->build_prefix()));
-  return str_startswith(std::string(request->url()_to.c_str()), this->build_prefix());
+  return str_startswith(std::string(request->url_to().c_str()), this->build_prefix());
 }
 
 void SDFileServer::handleRequest(AsyncWebServerRequest *request) {

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -74,9 +74,8 @@ void SDFileServer::handleUpload(AsyncWebServerRequest *request, const std::strin
     return;
   }
   this->sd_mmc_card_->append_file(Path::join(path, file_name).c_str(), data, len);
-  if (final) {
-    auto response = request->beginResponse(302, "text/plain", "");
-    response->addHeader("Location", request->url().c_str());
+   if (final) {
+    auto response = request->beginResponse(201, "text/html", "upload success");
     response->addHeader("Connection", "close");
     request->send(response);
     return;

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -75,8 +75,8 @@ void SDFileServer::handleUpload(AsyncWebServerRequest *request, const std::strin
   }
   this->sd_mmc_card_->append_file(Path::join(path, file_name).c_str(), data, len);
   if (final) {
-    auto response = request->beginResponse(303, "text/plain", "");
-    response->addHeader("Location", request->url());
+    auto response = request->beginResponse(302, "text/plain", "");
+    response->addHeader("Location", request->url().c_str());
     response->addHeader("Connection", "close");
     request->send(response);
     return;

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -306,7 +306,8 @@ void SDFileServer::handle_index(AsyncWebServerRequest *request, std::string cons
 
   response->print("</tbody></table>"
                     "<script>"
-                    "function delete_file(path) {fetch(path, {method: \"DELETE\"});}"
+                    
+                    "function delete_file(path) {fetch(path + '?delete=1')    .then(r => r.text())    .then(() => location.reload())    .catch(console.error);}"
                     "function download_file(path, filename) {"
                     "fetch(path).then(response => response.blob())"
                     ".then(blob => {"

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -24,7 +24,7 @@ void SDFileServer::dump_config() {
 }
 
 bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
-  if (url == "/favicon.ico" || url == "/robots.txt") { return false; }
+  if (request->url == "/favicon.ico" || request->url == "/robots.txt") { return false; }
   ESP_LOGD(TAG, "can handle %s %u", request->url().c_str(),
            str_startswith(std::string(request->url().c_str()), this->build_prefix()));
   return str_startswith(std::string(request->url().c_str()), this->build_prefix());

--- a/components/sd_file_server/sd_file_server.cpp
+++ b/components/sd_file_server/sd_file_server.cpp
@@ -30,7 +30,7 @@ bool SDFileServer::canHandle(AsyncWebServerRequest *request) const {
   }
   const char *prefix = this->build_prefix().c_str();
   bool match = str_startswith(url, prefix);
-  ESP_LOGD(TAG, "can handle %s %u", url, match);
+  ESP_LOGD(TAG, "can a handle %s %u", url, match);
   return match;
 }
 

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -123,7 +123,7 @@ SD_MMC_WRITE_FILE_ACTION_SCHEMA = cv.Schema(
 ).extend(SD_MMC_PATH_ACTION_SCHEMA)
 
 @automation.register_action(
-    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA , fasle
+    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA , false
 )
 async def sd_mmc_write_file_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -123,7 +123,7 @@ SD_MMC_WRITE_FILE_ACTION_SCHEMA = cv.Schema(
 ).extend(SD_MMC_PATH_ACTION_SCHEMA)
 
 @automation.register_action(
-    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA , False
+    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA 
 )
 async def sd_mmc_write_file_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -136,7 +136,7 @@ async def sd_mmc_write_file_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "sd_mmc_card.append_file", SdMmcAppendFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA
+    "sd_mmc_card.append_file", SdMmcAppendFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA , synchronous=False
 )
 async def sd_mmc_append_file_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -149,7 +149,7 @@ async def sd_mmc_append_file_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "sd_mmc_card.create_directory", SdMmcCreateDirectoryAction, SD_MMC_PATH_ACTION_SCHEMA
+    "sd_mmc_card.create_directory", SdMmcCreateDirectoryAction, SD_MMC_PATH_ACTION_SCHEMA , synchronous=False
 )
 async def sd_mmc_create_directory_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -160,7 +160,7 @@ async def sd_mmc_create_directory_to_code(config, action_id, template_arg, args)
 
 
 @automation.register_action(
-    "sd_mmc_card.remove_directory", SdMmcRemoveDirectoryAction, SD_MMC_PATH_ACTION_SCHEMA
+    "sd_mmc_card.remove_directory", SdMmcRemoveDirectoryAction, SD_MMC_PATH_ACTION_SCHEMA , synchronous=False
 )
 async def sd_mmc_remove_directory_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -171,7 +171,7 @@ async def sd_mmc_remove_directory_to_code(config, action_id, template_arg, args)
 
 
 @automation.register_action(
-    "sd_mmc_card.delete_file", SdMmcDeleteFileAction, SD_MMC_PATH_ACTION_SCHEMA
+    "sd_mmc_card.delete_file", SdMmcDeleteFileAction, SD_MMC_PATH_ACTION_SCHEMA , synchronous=False
 )
 async def sd_mmc_delete_file_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -123,7 +123,7 @@ SD_MMC_WRITE_FILE_ACTION_SCHEMA = cv.Schema(
 ).extend(SD_MMC_PATH_ACTION_SCHEMA)
 
 @automation.register_action(
-    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA 
+    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA , synchronous=False
 )
 async def sd_mmc_write_file_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -123,7 +123,7 @@ SD_MMC_WRITE_FILE_ACTION_SCHEMA = cv.Schema(
 ).extend(SD_MMC_PATH_ACTION_SCHEMA)
 
 @automation.register_action(
-    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA , false
+    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA , False
 )
 async def sd_mmc_write_file_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/components/sd_mmc_card/__init__.py
+++ b/components/sd_mmc_card/__init__.py
@@ -123,7 +123,7 @@ SD_MMC_WRITE_FILE_ACTION_SCHEMA = cv.Schema(
 ).extend(SD_MMC_PATH_ACTION_SCHEMA)
 
 @automation.register_action(
-    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA
+    "sd_mmc_card.write_file", SdMmcWriteFileAction, SD_MMC_WRITE_FILE_ACTION_SCHEMA , fasle
 )
 async def sd_mmc_write_file_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])


### PR DESCRIPTION
### Summary

This PR introduces the following minor improvements:

- Add a workaround to ensure DELETE requests work correctly in both Arduino and ESP-IDF environments
- Add `synchronous=false` to `register_action()` to remove compile-time warnings and align with current ESPHome API requirements

### Credits

This implementation builds upon the original work from this repository.  
Thanks to the original author for providing the excellent initial SD file server implementation abd ESPHome component.

### Testing

Tested successfully on:

- ESP32-S3 Pocket-Dongle-S3 (N16R8)
- 0.96" onboard display
- ESPHome (ESP-IDF and Arduino)

Verified features:

- File upload
- File download
- File deletion
- Directory navigation
- Web UI refresh after operations